### PR TITLE
Add Nuvoton chip ID 0xC562 (NCT5532D)

### DIFF
--- a/lib/nct5532d.cc
+++ b/lib/nct5532d.cc
@@ -32,7 +32,7 @@ std::map<NuvotonTempSource, uint8_t> kNCT5532DTempSource{
 };
 
 const NuvotonChipInfo kNCT5532D = {
-    {{0xC561, "NCT5532D"}},
+    {{0xC561, "NCT5532D"}, {0xC562, "NCT5532D"}},
     /*vendor_id_addr=*/{0, 0x4F},
     // Fan speed info
     {


### PR DESCRIPTION
**Add support for Nuvoton chip 0xC562 (NCT5562D)**
- Adds chip ID 0xC562 to the known Nuvoton chip list in `lib/nct5532d.cc`.
- Tested on FreeBSD 14.3 via `sudo bsdsensors --debug`.
- Related to #2 (Nuvoton chip unknown).